### PR TITLE
Add picolibc compatibilty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,15 @@ CCONF_H	?=	config.h
 XCHAIN	?= 	riscv64-unknown-elf-
 CFLAGS	= 	-O2 -Wall -g -mabi=ilp32 -march=rv32imc
 CFLAGS	+=	-include $(CCONF_H) -DNDEBUG
-LDFLAGS	= 	-Wl,-Bstatic,-T,flow/riscv.ld,--no-relax
+# If we use picolibc, adapt the flags.
+# NOTE: the local ld script mostly provides flash and RAM layout
+# (in our case flash starts at 0 and is in fact part of RAM)
+ifeq ($(USE_PICOLIBC),1)
+    CFLAGS      +=      -specs=picolibc.specs
+    LDFLAGS	= 	-Wl,-Bstatic,-T,flow/picolibc.ld,--no-relax
+else
+    LDFLAGS	= 	-Wl,-Bstatic,-T,flow/riscv.ld,--no-relax
+endif
 KATNUM	?=	10
 CFLAGS	+=	-DKATNUM=$(KATNUM)
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ See [slh/README.md](slh/README.md) for more information.
 
 As a prerequisite for simulation, you'll need:
 
-*   [Verilator](https://github.com/verilator/verilator) verilog simulator.
+*   [Verilator](https://github.com/verilator/verilator) verilog simulator. This might be packaged on some Linux distros.
 *   A RISC-V cross-compiler that supports bare-metal targets. You can build a suitable [riscv-gnu-toolchain](https://github.com/riscv/riscv-gnu-toolchain)
-with `./configure --enable-multilib` and `make newlib`.
+with `./configure --enable-multilib` and `make newlib`. Under some Linux based distros (such as Debian), it is possible to use the packaged
+`gcc-riscv64-unknown-elf` along with the packaged `picolibc-riscv64-unknown-elf`: note that in this case, you will have to export the `USE_PICOLIBC=1` environment
+variable when compiling: `USE_PICOLIBC=1 make veri` (this is due to some divergence between `newlib` and `picolibc` C standard libraries linking scripts).
 
-Both of these may be available as packages for Linux operating systems. The name of your toolchain is set in `XCHAIN` variable in the [Makefile](Makefile).
+The name of your toolchain is set in `XCHAIN` variable in the [Makefile](Makefile).
 
 To build and run a quick end-to-end test, try:
 ```

--- a/drv/main.c
+++ b/drv/main.c
@@ -18,6 +18,36 @@ int test_sloth();       //  test_sloth.c
 int test_bench();       //  test_bench.c
 int test_leak();        //  test_leak.c
 
+#ifdef _PICOLIBC__
+// XXX In case of Picolibc, redirect stdio related stuff to uart
+// (see https://github.com/picolibc/picolibc/blob/main/doc/os.md)
+// This allows to use printf family of functions
+#include <stdio.h>
+#include <stdlib.h>
+static int sample_putc(char c, FILE *file)
+{
+        (void) file;            /* Not used in this function */
+        sio_putc(c);            /* Defined by underlying system */
+        return c;
+}
+
+static int sample_getc(FILE *file)
+{
+        unsigned char c;
+        (void) file;            /* Not used in this function */
+        c = sio_getc();         /* Defined by underlying system */
+        return c;
+}
+
+FILE __stdio = FDEV_SETUP_STREAM(sample_putc,
+                                        sample_getc,
+                                        NULL,
+                                        _FDEV_SETUP_RW);
+
+FILE *const stdin = &__stdio; __strong_reference(stdin, stdout); __strong_reference(stdin, stderr);
+#endif
+
+
 int main()
 {
     int fail = 0;
@@ -68,6 +98,11 @@ int main()
     sio_putc(4);  //  translated to EOF
     sio_putc(0);
 
+#ifdef _PICOLIBC__
+    // XXX: in case of picolibc, explicitly exit as
+    // this is not performed at the return of main
+    exit(0);
+#endif
     return 0;
 }
 

--- a/flow/eprof.py
+++ b/flow/eprof.py
@@ -56,7 +56,12 @@ for rfn in lsc:
 	pfl=len(os.path.commonprefix([os.getcwd(), rfn]))
 	wfn = rfn[pfl:].replace("/","_");
 	print("writing:", wfn)
-	fr = open(rfn, "r")
+	try:
+		# Try to open the source file, if not possible skip it
+		fr = open(rfn, "r")
+	except:
+		print("[-] Skipping %s (not found)" % wfn)
+		continue
 	fw = open(wfn, "w")
 	ln = 0
 	for sf in fr:

--- a/flow/eprof.py
+++ b/flow/eprof.py
@@ -55,13 +55,13 @@ fw.close()
 for rfn in lsc:
 	pfl=len(os.path.commonprefix([os.getcwd(), rfn]))
 	wfn = rfn[pfl:].replace("/","_");
-	print("writing:", wfn)
 	try:
 		# Try to open the source file, if not possible skip it
 		fr = open(rfn, "r")
 	except:
-		print("[-] Skipping %s (not found)" % wfn)
+		print("[-] Skipping %s (not found)" % rfn)
 		continue
+	print("writing:", wfn)
 	fw = open(wfn, "w")
 	ln = 0
 	for sf in fr:

--- a/flow/picolibc.ld
+++ b/flow/picolibc.ld
@@ -1,0 +1,6 @@
+# XXX: sizes to be fixed according to the (hardware) allocated RAM size of SLotH
+__flash = 0x00000000;
+__flash_size = 64k;
+__ram = __flash + __flash_size;
+__ram_size = 64k;
+__stack_size = 8k;


### PR DESCRIPTION
This PR adds `picolibc` C standard library (https://github.com/picolibc/picolibc) compatibility. This is useful e.g. under Debian and some other distros where the RISC-V toolchain comes with a packaged `picolibc` but no packaged `newlib` for this target.

Under Debian `trixie` or Ubuntu `jammy`:

`$ sudo apt install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
`

The PR should not break the regular original compilation with `newlib` as it is only activated when the environment variable `USE_PICOLIBC=1` is exported.

The profiling script `flow/eprof.py` has been adapted to handle cases where source references from the debug symbols are not present in the toolchain (in this case the script skips these files).